### PR TITLE
Add feature to automatically set the membership end date to the end of month

### DIFF
--- a/api/v3/Job/Adjustmembershipenddate.php
+++ b/api/v3/Job/Adjustmembershipenddate.php
@@ -1,0 +1,55 @@
+<?php
+
+use Civi\Api4\Membership;
+use CRM_Membershiputils_ExtensionUtil as E;
+
+/**
+ * Job.Adjustmembershipenddate API specification (optional)
+ * This is used for documentation and validation.
+ *
+ * @param array $spec description of fields supported by this API call
+ *
+ * @see https://docs.civicrm.org/dev/en/latest/framework/api-architecture/
+ */
+function _civicrm_api3_job_Adjustmembershipenddate_spec(&$spec) {
+}
+
+/**
+ * Job.Adjustmembershipenddate API
+ *
+ * Scheduled job which will bulk adjust the membership end date for all
+ * membership, setting the end date to the end of month
+ *
+ * @param array $params
+ *
+ * @return array
+ *   API result descriptor
+ *
+ * @throws API_Exception
+ * @see civicrm_api3_create_success
+ *
+ */
+function civicrm_api3_job_Adjustmembershipenddate($params) {
+  try {
+    // Get all memberships
+    $memberships = Membership::get()
+      ->addSelect('id', 'end_date')
+      ->execute()->getArrayCopy();
+    foreach ($memberships as $membership) {
+      // Calculate the end of month date for the membership
+      $end_date = date_create($membership['end_date']);
+      $start_month = date_create($end_date->format('Y-m') . '-01');
+      $new_end_date = date_modify($start_month, '+1 month -1 day');
+
+      // Update the membership
+      Membership::update()
+        ->addValue('end_date', $new_end_date->format('Y-m-d'))
+        ->addWhere('id', '=', $membership['id'])
+        ->execute();
+    }
+    return civicrm_api3_create_success(TRUE, $params, 'membershiputils', 'Adjustmembershipenddate');
+  }
+  catch (Exception $e) {
+    throw new CRM_Core_Exception('Error updating adjusting membership end date. Error: ' . $e->getMessage());
+  }
+}

--- a/api/v3/Membershiputils/Findduplicatememberships.php
+++ b/api/v3/Membershiputils/Findduplicatememberships.php
@@ -1,4 +1,5 @@
 <?php
+
 use CRM_Membershiputils_ExtensionUtil as E;
 
 /**
@@ -38,6 +39,6 @@ function civicrm_api3_membershiputils_Findduplicatememberships() {
     return civicrm_api3_create_success(TRUE, $params, 'membershiputils', 'Findduplicatememberships');
   }
   catch (Exception $e) {
-    throw new CRM_Core_Exception('Error marking memberships as duplicate. Error: ' . $e->getMessage() );
+    throw new CRM_Core_Exception('Error marking memberships as duplicate. Error: ' . $e->getMessage());
   }
 }

--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Support">https://agileware.com.au/contact</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2022-04-11</releaseDate>
-  <version>1.1</version>
+  <releaseDate>2022-05-25</releaseDate>
+  <version>1.2</version>
   <develStage>beta</develStage>
   <compatibility>
     <ver>5.0</ver>
@@ -27,4 +27,7 @@
   <civix>
     <namespace>CRM/Membershiputils</namespace>
   </civix>
+  <mixins>
+    <mixin>mgd-php@1.0.0</mixin>
+  </mixins>
 </extension>

--- a/mixin/mgd-php@1.0.0.mixin.php
+++ b/mixin/mgd-php@1.0.0.mixin.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Auto-register "**.mgd.php" files.
+ *
+ * @mixinName mgd-php
+ * @mixinVersion 1.0.0
+ *
+ * @param CRM_Extension_MixInfo $mixInfo
+ *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.
+ * @param \CRM_Extension_BootCache $bootCache
+ *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.
+ */
+return function ($mixInfo, $bootCache) {
+
+  /**
+   * @param \Civi\Core\Event\GenericHookEvent $e
+   * @see CRM_Utils_Hook::managed()
+   */
+  Civi::dispatcher()->addListener('hook_civicrm_managed', function ($event) use ($mixInfo) {
+    // When deactivating on a polyfill/pre-mixin system, listeners may not cleanup automatically.
+    if (!$mixInfo->isActive()) {
+      return;
+    }
+
+    $mgdFiles = CRM_Utils_File::findFiles($mixInfo->getPath(), '*.mgd.php');
+    sort($mgdFiles);
+    foreach ($mgdFiles as $file) {
+      $es = include $file;
+      foreach ($es as $e) {
+        if (empty($e['module'])) {
+          $e['module'] = $mixInfo->longName;
+        }
+        if (empty($e['params']['version'])) {
+          $e['params']['version'] = '3';
+        }
+        $event->entities[] = $e;
+      }
+    }
+  });
+
+};

--- a/mixin/polyfill.php
+++ b/mixin/polyfill.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * When deploying on systems that lack mixin support, fake it.
+ *
+ * @mixinFile polyfill.php
+ *
+ * This polyfill does some (persnickity) deduplication, but it doesn't allow upgrades or shipping replacements in core.
+ *
+ * Note: The polyfill.php is designed to be copied into extensions for interoperability. Consequently, this file is
+ * not used 'live' by `civicrm-core`. However, the file does need a canonical home, and it's convenient to keep it
+ * adjacent to the actual mixin files.
+ *
+ * @param string $longName
+ * @param string $shortName
+ * @param string $basePath
+ */
+return function ($longName, $shortName, $basePath) {
+  // Construct imitations of the mixin services. These cannot work as well (e.g. with respect to
+  // number of file-reads, deduping, upgrading)... but they should be OK for a few months while
+  // the mixin services become available.
+
+  // List of active mixins; deduped by version
+  $mixinVers = [];
+  foreach ((array) glob($basePath . '/mixin/*.mixin.php') as $f) {
+    [$name, $ver] = explode('@', substr(basename($f), 0, -10));
+    if (!isset($mixinVers[$name]) || version_compare($ver, $mixinVers[$name], '>')) {
+      $mixinVers[$name] = $ver;
+    }
+  }
+  $mixins = [];
+  foreach ($mixinVers as $name => $ver) {
+    $mixins[] = "$name@$ver";
+  }
+
+  // Imitate CRM_Extension_MixInfo.
+  $mixInfo = new class() {
+
+    /**
+     * @var string
+     */
+    public $longName;
+
+    /**
+     * @var string
+     */
+    public $shortName;
+
+    public $_basePath;
+
+    public function getPath($file = NULL) {
+      return $this->_basePath . ($file === NULL ? '' : (DIRECTORY_SEPARATOR . $file));
+    }
+
+    public function isActive() {
+      return \CRM_Extension_System::singleton()->getMapper()->isActiveModule($this->shortName);
+    }
+
+  };
+  $mixInfo->longName = $longName;
+  $mixInfo->shortName = $shortName;
+  $mixInfo->_basePath = $basePath;
+
+  // Imitate CRM_Extension_BootCache.
+  $bootCache = new class() {
+
+    public function define($name, $callback) {
+      $envId = \CRM_Core_Config_Runtime::getId();
+      $oldExtCachePath = \Civi::paths()->getPath("[civicrm.compile]/CachedExtLoader.{$envId}.php");
+      $stat = stat($oldExtCachePath);
+      $file = Civi::paths()->getPath('[civicrm.compile]/CachedMixin.' . md5($name . ($stat['mtime'] ?? 0)) . '.php');
+      if (file_exists($file)) {
+        return include $file;
+      }
+      else {
+        $data = $callback();
+        file_put_contents($file, '<' . "?php\nreturn " . var_export($data, 1) . ';');
+        return $data;
+      }
+    }
+
+  };
+
+  // Imitate CRM_Extension_MixinLoader::run()
+  // Parse all live mixins before trying to scan any classes.
+  global $_CIVIX_MIXIN_POLYFILL;
+  foreach ($mixins as $mixin) {
+    // If the exact same mixin is defined by multiple exts, just use the first one.
+    if (!isset($_CIVIX_MIXIN_POLYFILL[$mixin])) {
+      $_CIVIX_MIXIN_POLYFILL[$mixin] = include_once $basePath . '/mixin/' . $mixin . '.mixin.php';
+    }
+  }
+  foreach ($mixins as $mixin) {
+    // If there's trickery about installs/uninstalls/resets, then we may need to register a second time.
+    if (!isset(\Civi::$statics[__FUNCTION__][$mixin])) {
+      \Civi::$statics[__FUNCTION__][$mixin] = 1;
+      $func = $_CIVIX_MIXIN_POLYFILL[$mixin];
+      $func($mixInfo, $bootCache);
+    }
+  }
+};

--- a/settings/Membershiputils.setting.php
+++ b/settings/Membershiputils.setting.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+  'adjust_membership_end_date' => [
+    'name' => 'adjust_membership_end_date',
+    'type' => 'Boolean',
+    'quick_form_type' => 'YesNo',
+    'default' => 0,
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'title' => ts('Adjust membership end date'),
+    'description' => ts('Automatically adjust the membership end date to the end of the month. For example: a membership with an end date of 16/04/2022 will be changed to 30/04/2022.'),
+    'settings_pages' => ['membershiputils' => ['weight' => 10]],
+  ],
+];

--- a/xml/Menu/membershiputils.xml
+++ b/xml/Menu/membershiputils.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<menu>
+    <item>
+        <path>civicrm/admin/setting/membershiputils</path>
+        <title>Membership Utilities Settings</title>
+        <page_callback>CRM_Admin_Form_Generic</page_callback>
+        <access_arguments>administer CiviCRM</access_arguments>
+    </item>
+</menu>


### PR DESCRIPTION
Add feature to automatically set the membership end date to the end of month.
Includes Scheduled Job to bulk update all existing memberships.
Membership Utilities now has a Settings page which is required to enable or disable this feature.

The Scheduled Job and the option to change the membership end date is disabled by default.

Ping @agileware-fj 

Agileware Ref: PROJ-2290